### PR TITLE
Fixes redux-remember interoperability with next-redux-wrapper

### DIFF
--- a/lib/store.ts
+++ b/lib/store.ts
@@ -30,11 +30,13 @@ const sliceFromClient = createSlice({
     value: 0,
   },
   reducers: {
-    increment: (state) => {
+    incrementClient: (state) => {
       state.value += 1;
     },
   },
 });
+
+export const { incrementClient } = sliceFromClient.actions;
 
 const rootReducer = combineReducers({
   fromServer: sliceFromServer.reducer,
@@ -44,17 +46,17 @@ const rootReducer = combineReducers({
 const enhancer = rememberEnhancer(
   // shim to emulate local storage on the server
   Persist(StorageKind.local),
-  ['sliceFromClient'],
+  ['fromClient'],
   { prefix: '~' }
 );
 
-export const createStore = () =>
-  configureStore({
-    reducer: rememberReducer(rootReducer) as typeof rootReducer,
-    // reducer: rootReducer,
-    devTools: process.env.NODE_ENV !== 'production',
-    enhancers: [enhancer],
-  });
+let storeInstance = configureStore({
+  reducer: rememberReducer(rootReducer) as typeof rootReducer,
+  devTools: process.env.NODE_ENV !== 'production',
+  enhancers: [enhancer],
+});
+
+export const createStore = () => storeInstance; 
 
 export type AppStore = ReturnType<typeof createStore>;
 export type RootState = ReturnType<AppStore['getState']>;

--- a/lib/store.ts
+++ b/lib/store.ts
@@ -47,16 +47,17 @@ const enhancer = rememberEnhancer(
   // shim to emulate local storage on the server
   Persist(StorageKind.local),
   ['fromClient'],
-  { prefix: '~' }
+  {
+    prefix: '~',
+    initActionType: HYDRATE
+  }
 );
 
-let storeInstance = configureStore({
+export const createStore = () => configureStore({
   reducer: rememberReducer(rootReducer) as typeof rootReducer,
   devTools: process.env.NODE_ENV !== 'production',
   enhancers: [enhancer],
-});
-
-export const createStore = () => storeInstance; 
+});; 
 
 export type AppStore = ReturnType<typeof createStore>;
 export type RootState = ReturnType<AppStore['getState']>;

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "next": "^12.3.4",
         "next-redux-wrapper": "^8.1.0",
         "react-redux": "^8.1.3",
-        "redux-remember": "^4.0.4"
+        "redux-remember": "^4.2.1"
       },
       "devDependencies": {
         "@types/node": "^20.9.0",
@@ -3145,9 +3145,9 @@
       }
     },
     "node_modules/redux-remember": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/redux-remember/-/redux-remember-4.0.4.tgz",
-      "integrity": "sha512-a1T+UMYTa08Uq0YtCp0j5Z7v5yydbePPgfu4iAZ21Uk4ozcFfT/PoB9PwETFhHRxBW4Ij0yWPfPJw3mIE/CXlw==",
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/redux-remember/-/redux-remember-4.2.1.tgz",
+      "integrity": "sha512-4rmlzGnXbzhMeMivW/sgaVX/KZyFb6yp9oWV9Mu0lw/4IUM3eoClANZjny27p3t6cTcf/OsTZcCjKwyCujwqAQ==",
       "peerDependencies": {
         "redux": "*"
       }
@@ -6077,9 +6077,9 @@
       }
     },
     "redux-remember": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/redux-remember/-/redux-remember-4.0.4.tgz",
-      "integrity": "sha512-a1T+UMYTa08Uq0YtCp0j5Z7v5yydbePPgfu4iAZ21Uk4ozcFfT/PoB9PwETFhHRxBW4Ij0yWPfPJw3mIE/CXlw==",
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/redux-remember/-/redux-remember-4.2.1.tgz",
+      "integrity": "sha512-4rmlzGnXbzhMeMivW/sgaVX/KZyFb6yp9oWV9Mu0lw/4IUM3eoClANZjny27p3t6cTcf/OsTZcCjKwyCujwqAQ==",
       "requires": {}
     },
     "redux-thunk": {

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "next": "^12.3.4",
     "next-redux-wrapper": "^8.1.0",
     "react-redux": "^8.1.3",
-    "redux-remember": "^4.0.4"
+    "redux-remember": "^4.2.1"
   },
   "devDependencies": {
     "@types/node": "^20.9.0",

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,8 +1,10 @@
-import { increment, useTypedSelector, wrapper } from 'lib/store';
+import { increment, incrementClient, useTypedSelector, wrapper } from 'lib/store';
+import { useDispatch } from 'react-redux';
 
 const Page = () => {
   const serverState = useTypedSelector((state) => state.fromServer.value);
   const clientState = useTypedSelector((state) => state.fromClient.value);
+  const dispatch = useDispatch();
 
   return (
     <div>
@@ -13,6 +15,11 @@ const Page = () => {
 
       <h2>Client</h2>
       <p>{clientState}</p>
+      <p>
+        <button onClick={() => dispatch(incrementClient())}>
+          Increment client
+        </button>
+      </p>
     </div>
   );
 };


### PR DESCRIPTION
Added a new option to `redux-remember` which allows it to initialize after `next-redux-wrapper` has rehydrated from the SSR state. With this new option `redux-remember` waits until the `HYDRATE` action is dispatched by `next-redux-wrapper`. Example follows:

```ts
// ...
rememberEnhancer(
  Persist(StorageKind.local),
  ['fromClient'],
  {
    prefix: '~',
    initActionType: HYDRATE
  }
);
// ...
```